### PR TITLE
perf(images): lazy-load de imágenes en cards y listas

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -37,7 +37,7 @@
 	{#if mark}
 		<span class="card-mark">{mark}</span>
 	{/if}
-	<img class="card-img u-featured placeholder-gradient" {src} alt="" />
+	<img class="card-img u-featured placeholder-gradient" {src} alt="" loading="lazy" />
 	<h3 class="p-name">
 		{title}
 		{#if pronoun && (pronoun + '').split('/').pop() != 'evitar'}

--- a/src/lib/components/PostListItem.svelte
+++ b/src/lib/components/PostListItem.svelte
@@ -158,7 +158,7 @@
 			<span class="job-title">{job_title}</span>
 		{/if}
 	</div>
-	{#if src}<img {src} alt="" />{/if}
+	{#if src}<img {src} alt="" loading="lazy" decoding="async" />{/if}
 	<h3>
 		{title}
 		{#if pronoun && (pronoun + '').split('/').pop() != 'evitar'}


### PR DESCRIPTION
## Qué

Agrega `loading="lazy"` a las imágenes compartidas de `Card.svelte` y `PostListItem.svelte` (las cards de la home y los items de la lista de posts), más `decoding="async"` en la imagen de la lista.

Dos líneas:

```diff
- <img class="card-img u-featured placeholder-gradient" {src} alt="" />
+ <img class="card-img u-featured placeholder-gradient" {src} alt="" loading="lazy" />

- {#if src}<img {src} alt="" />{/if}
+ {#if src}<img {src} alt="" loading="lazy" decoding="async" />{/if}
```

## Por qué

La home renderiza la lista completa de posts, así que **todas** las imágenes below-the-fold se traían eager en la carga inicial.

## Medición

Build de producción, home en 1366×768, bytes reales del servidor (vía HEAD, sin cache):

| | Requests de imagen en carga inicial | Peso |
|---|---|---|
| **Antes** (todo eager) | 87 | ~36.7 MB |
| **Después** (lazy) | 14 | ~2.5 MB |
| **Ahorro** | **−73 requests** | **−34 MB (~93% del peso de imágenes diferido)** |

Impacto especialmente notable en móvil / conexiones lentas.

## Verificación

- `npm run check`: sin errores nuevos (los preexistentes son de otros archivos).
- Build + `preview`, navegador real: las imágenes diferidas cargan correctamente al scrollear (39 → 107 cargadas), sin imágenes rotas.
- Sin layout shift: el tamaño de las imágenes lo maneja el CSS (`Card` con `height` fijo, `PostListItem` con grid de columna fija).

## Notas

- No se marca ninguna imagen como `eager`/LCP: las imágenes de card están sobre un gradient y en scroll horizontal, no son el elemento LCP.
- Próximo gran salto (fuera de este PR): optimizar formatos/tamaños de imagen (esos ~36 MB son imágenes sin optimizar), lo que requeriría `sharp`/`vite-imagetools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)