### PR TITLE
feat(posts): tiempo de lectura estimado en material y wiki (#21)

### DIFF
--- a/src/lib/components/ReadingTime.svelte
+++ b/src/lib/components/ReadingTime.svelte
@@ -1,0 +1,102 @@
+<script>
+	import { BookOpen, Info } from 'lucide-svelte';
+	import { createTooltip, melt } from '@melt-ui/svelte';
+	import { fade } from 'svelte/transition';
+
+	/** Minutos estimados de lectura. @type {number} */
+	export let minutes;
+
+	const {
+		elements: { trigger, content, arrow },
+		states: { open }
+	} = createTooltip({
+		positioning: { placement: 'top' },
+		openDelay: 150,
+		closeDelay: 0,
+		closeOnPointerDown: false, // en touch: el tap abre, no cierra al instante
+		forceVisible: true,
+		group: 'reading-time'
+	});
+</script>
+
+{#if Number.isFinite(minutes) && minutes > 0}
+	<span class="reading-time" title="Tiempo de lectura estimado">
+		<BookOpen class="rt-icon" size={14} aria-hidden="true" />
+		<span class="rt-label">~{minutes} min de lectura</span>
+		<button
+			type="button"
+			class="rt-info"
+			use:melt={$trigger}
+			aria-label="Cómo se calcula el tiempo de lectura"
+		>
+			<Info size={13} aria-hidden="true" />
+		</button>
+	</span>
+
+	{#if $open}
+		<div use:melt={$content} class="rt-tooltip" transition:fade={{ duration: 100 }}>
+			<div use:melt={$arrow} />
+			<p>Tiempo de lectura estimado a ~200 palabras por minuto.</p>
+		</div>
+	{/if}
+{/if}
+
+<style lang="scss">
+	.reading-time {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25em;
+		font-size: var(--step--2);
+		opacity: 0.75;
+		white-space: nowrap;
+		vertical-align: baseline;
+	}
+	.reading-time :global(.rt-icon) {
+		color: var(--2);
+		flex: none;
+		translate: 0 0.06em;
+	}
+	.rt-info {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.25em; // área de tap cómoda sin agrandar el texto
+		margin: -0.25em -0.1em -0.25em -0.05em;
+		background: none;
+		border: 0;
+		color: inherit;
+		opacity: 0.7;
+		cursor: help;
+		border-radius: 0.3em;
+	}
+	.rt-info:hover,
+	.rt-info:focus-visible {
+		opacity: 1;
+		color: var(--2);
+	}
+	.rt-tooltip {
+		z-index: 50;
+		max-width: 15rem;
+		padding: 0.35em 0.6em;
+		font-size: var(--step--2);
+		line-height: 1.3;
+		color: #222;
+		background: color-mix(in srgb, var(--2) 8%, white);
+		border: 1px solid var(--2-light);
+		border-radius: 0.4em;
+		box-shadow: 0 0.3em 0.8em -0.3em color-mix(in srgb, var(--2) 30%, transparent);
+		opacity: 1;
+	}
+	.rt-tooltip p {
+		margin: 0;
+	}
+	.rt-tooltip :global([data-melt-tooltip-arrow]) {
+		border-top: 1px solid var(--2-light);
+		border-left: 1px solid var(--2-light);
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.rt-tooltip {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/types.d.js
+++ b/src/lib/types.d.js
@@ -73,6 +73,7 @@
  * @prop {string} [updated_date]
  * @prop {boolean} [force_unlisted]
  * @prop {boolean} [force_unpublished]
+ * @prop {number} [readingTime] - minutos estimados de lectura (solo material/wiki)
  */
 /** @typedef {PostData & {
  * 		type: 'descargable' | 'link' | 'contenido',

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,5 +1,18 @@
 import '$lib/types.d.js';
 import tagsFactory from './tags';
+import { estimateReadingTime } from './readingTime';
+
+/** Loaders perezosos del markdown CRUDO de cada post, para estimar el tiempo de
+ * lectura en build-time sin extraer texto del componente compilado. `eager: false`
+ * ⇒ cada detalle carga solo su propio `.md`, igual que el componente. */
+const rawPostLoaders = import.meta.glob('$lib/posts/*/*.md', { query: '?raw', import: 'default' });
+/** Índice O(1) `categoría/postID` → loader del .md crudo (la key del glob es el path). */
+const rawPostByKey = new Map(
+	Object.entries(rawPostLoaders).map(([path, load]) => {
+		const m = path.match(/\/posts\/([^/]+)\/([^/]+)\.md$/);
+		return [m ? `${m[1]}/${m[2]}` : path, load];
+	})
+);
 
 /**Calls fn for the group and every subgroup and returns the resulting group.
  * @param {Group} group
@@ -73,6 +86,21 @@ export function aliaserFactory(tagManager = tagsFactory()) {
 export const fetchPost = async (category, postID, shallow = false) => {
 	let { default: postContent, metadata: meta } = await import(`../posts/${category}/${postID}.md`);
 	if (meta?.force_unpublished) throw Error('Post is unpublished');
+	// Tiempo de lectura: solo en el contenido pensado para leerse (material/wiki) y
+	// solo en la carga completa (no en lookups shallow de perfiles de autories).
+	if (meta && !shallow && (category === 'material' || category === 'wiki')) {
+		const loadRaw = rawPostByKey.get(`${category}/${postID}`);
+		if (loadRaw) {
+			try {
+				meta = {
+					...meta,
+					readingTime: estimateReadingTime(/** @type {string} */ (await loadRaw()))
+				};
+			} catch (e) {
+				// si falla la lectura del crudo, omitimos readingTime sin tirar la página
+			}
+		}
+	}
 	return await processPost(postContent, postID, meta, shallow);
 };
 
@@ -222,7 +250,12 @@ export const processContent = async (node) => {
 		} catch (e) {
 			return;
 		}
-		if (post.meta.pronoun == '' || !post.meta.pronoun || (post.meta.pronoun + '').split('/').pop() == 'evitar') return;
+		if (
+			post.meta.pronoun == '' ||
+			!post.meta.pronoun ||
+			(post.meta.pronoun + '').split('/').pop() == 'evitar'
+		)
+			return;
 		p.className = 'p-pronoun';
 		p.textContent =
 			' ' + (post?.meta.pronoun + '').split('/').pop()?.split(',')[0].replaceAll('&', '/') + '';

--- a/src/lib/utils/readingTime.js
+++ b/src/lib/utils/readingTime.js
@@ -1,0 +1,26 @@
+/**
+ * Estima el tiempo de lectura en minutos a partir del markdown crudo de un post.
+ *
+ * Cuenta palabras sobre el texto fuente (no el componente compilado de mdsvex):
+ * descarta frontmatter, bloques `<script>`/`<style>`, código, imágenes y sintaxis
+ * markdown/HTML. Es un estimado a propósito — no rastrea el texto generado por
+ * Svelte inline, y el tooltip de la UI lo aclara.
+ *
+ * @param {string} [rawMd] - contenido crudo del archivo `.md`
+ * @param {number} [wpm=200] - palabras por minuto (≈ lectura en español)
+ * @returns {number} minutos estimados, mínimo 1
+ */
+export function estimateReadingTime(rawMd, wpm = 200) {
+	if (!Number.isFinite(wpm) || wpm <= 0) wpm = 200;
+	const text = (rawMd ?? '')
+		.replace(/^---\r?\n[\s\S]*?\r?\n---/, '') // frontmatter YAML
+		.replace(/<script[\s\S]*?<\/script>/gi, '') // <script> de mdsvex
+		.replace(/<style[\s\S]*?<\/style>/gi, '')
+		.replace(/```[\s\S]*?```/g, '') // bloques de código
+		.replace(/`[^`]*`/g, '') // código inline
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, '') // imágenes
+		.replace(/<[^>]+>/g, ' ') // tags HTML/Svelte
+		.replace(/[#>*_~[\]()|]/g, ' '); // marcas de sintaxis markdown
+	const words = text.match(/\S+/g)?.length ?? 0;
+	return Math.max(1, Math.round(words / wpm));
+}

--- a/src/lib/utils/readingTime.test.js
+++ b/src/lib/utils/readingTime.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { estimateReadingTime } from './readingTime';
+
+const words = (/** @type {number} */ n) => Array.from({ length: n }, () => 'palabra').join(' ');
+
+describe('estimateReadingTime', () => {
+	it('cuenta ~200 palabras por minuto', () => {
+		expect(estimateReadingTime(words(200))).toBe(1);
+		expect(estimateReadingTime(words(500))).toBe(3); // 2.5 -> 3
+		expect(estimateReadingTime(words(1000))).toBe(5);
+	});
+
+	it('devuelve al menos 1 minuto', () => {
+		expect(estimateReadingTime('hola mundo')).toBe(1);
+		expect(estimateReadingTime('')).toBe(1);
+		expect(estimateReadingTime(undefined)).toBe(1);
+	});
+
+	it('ignora el frontmatter YAML', () => {
+		const md = `---\ntitle: Algo\ntags: [a, b, c]\nsummary: ${words(50)}\n---\n\n${words(400)}`;
+		expect(estimateReadingTime(md)).toBe(2); // 400/200, sin contar el frontmatter
+	});
+
+	it('ignora <script>, código e imágenes', () => {
+		const md = [
+			'<script>',
+			"  import Algo from './Algo.svelte';",
+			'</' + 'script>',
+			'',
+			'```js',
+			'const x = ' + words(300),
+			'```',
+			'',
+			'![un poster muy largo con mucho texto alt](/media/1.png)',
+			'',
+			words(200)
+		].join('\n');
+		expect(estimateReadingTime(md)).toBe(1); // solo cuentan las 200 palabras del cuerpo
+	});
+
+	it('respeta un wpm custom', () => {
+		expect(estimateReadingTime(words(300), 150)).toBe(2);
+	});
+});

--- a/src/routes/(content)/material/[post]/+page.svelte
+++ b/src/routes/(content)/material/[post]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import LDTag from '$lib/components/LDTag.svelte';
 	import Tags from '$lib/components/Tags.svelte';
+	import ReadingTime from '$lib/components/ReadingTime.svelte';
 	import PostList from '$lib/components/PostList.svelte';
 	import { currentPostData } from '$lib/utils/stores.js';
 	import { page } from '$app/stores';
@@ -22,8 +23,10 @@
 			) ||
 			(data.meta.wiki && p.meta.tags.includes(data.meta.wiki)) ||
 			(data.meta.category == 'wiki' && p.meta.tags.includes(data.meta.postID)) ||
-			(data.meta.category == 'amigues' && p.meta.authors.includes(data.meta.postID) && p.meta.postID != data.meta.postID)
-	)
+			(data.meta.category == 'amigues' &&
+				p.meta.authors.includes(data.meta.postID) &&
+				p.meta.postID != data.meta.postID)
+	);
 </script>
 
 <LDTag
@@ -100,6 +103,9 @@
 			</time>
 		</address>
 	{/if}
+	{#if data.meta.readingTime}
+		<div class="reading-time-row"><ReadingTime minutes={data.meta.readingTime} /></div>
+	{/if}
 	{#if data.meta.tags}
 		<div id="tags">
 			<Tags tags={data.meta.tags} />
@@ -170,6 +176,10 @@
 {/if}
 
 <style lang="scss">
+	.reading-time-row {
+		text-align: center;
+		margin: 0.3em 0;
+	}
 	#cafecito,
 	#via {
 		max-width: 50rem;

--- a/src/routes/(content)/wiki/[term]/+page.svelte
+++ b/src/routes/(content)/wiki/[term]/+page.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/stores';
 	import { ChevronLeft, ChevronRight } from 'lucide-svelte';
 	import MiniMarkup from '$lib/components/MiniMarkup.svelte';
+	import ReadingTime from '$lib/components/ReadingTime.svelte';
 	export let data;
 	currentPostData.set({ category: 'wiki', path: $page.url.pathname });
 
@@ -90,6 +91,9 @@
 <article class="h-entry wiki" id="title">
 	<div class="content">
 		<GlosarioItem item={data?.tag?.id ?? data?.meta?.wiki} single title />
+		{#if data.meta?.readingTime}
+			<div class="wiki-reading-time"><ReadingTime minutes={data.meta.readingTime} /></div>
+		{/if}
 		{#if data.content}
 			<svelte:component this={data.content} />
 		{/if}
@@ -102,13 +106,13 @@
 					{#each line as { name, disabled = false }}
 						<span class="line">
 							{#if disabled}
-							<ChevronLeft {style} /><span class="familiar-name">{name}</span>
-						{:else}
-							<ChevronLeft {style} /><a
-								class="familiar-name"
-								href={'/wiki/' + name.replaceAll(' ', '-')}>{name}</a
-							>
-						{/if}
+								<ChevronLeft {style} /><span class="familiar-name">{name}</span>
+							{:else}
+								<ChevronLeft {style} /><a
+									class="familiar-name"
+									href={'/wiki/' + name.replaceAll(' ', '-')}>{name}</a
+								>
+							{/if}
 						</span>
 					{/each}
 				</div>
@@ -147,6 +151,10 @@
 		font-size: var(--step-3);
 	}
 
+	.wiki-reading-time {
+		margin: 0.1em auto 0.9em; /* alinea con la columna de prosa centrada */
+	}
+
 	.lineage {
 		max-width: 45rem;
 		width: 100%;
@@ -168,7 +176,7 @@
 	}
 	.lineage a {
 		background: white;
-		padding: .2em .5em;
+		padding: 0.2em 0.5em;
 		border-radius: var(--round);
 		text-decoration: none;
 	}


### PR DESCRIPTION
Muestra un indicador discreto de tiempo de lectura en los detalles del post, antes del contenido, con un tooltip que aclara cómo se calcula y que es solo una referencia.

- estimateReadingTime(): cuenta palabras del .md crudo (excluye frontmatter, <script>, código e imágenes), ~200 ppm, mínimo 1 min.
- fetchPost lee el markdown crudo vía import.meta.glob('?raw') (lazy) y setea meta.readingTime — cálculo en build-time, sin medir el DOM ni layout-shift; solo material/wiki y no en lookups shallow.
- ReadingTime.svelte: indicador inline atenuado + tooltip accesible (Melt UI), hover en desktop / tap en mobile, prefers-reduced-motion.
- Inyectado en material/[post] (fila de detalles) y wiki/[term] (alineado con la columna de contenido).

Verificado: 5/5 unit tests, npm run check sin errores nuevos, probado en navegador desktop + mobile.
## Capturas

**Desktop** — indicador en la fila de detalles + tooltip:

![Tiempo de lectura — desktop](https://raw.githubusercontent.com/JorgeT10/kinkyvibe/pr46-assets/rt-material-desktop.png)

**Mobile** — tooltip al tocar el ícono:

![Tiempo de lectura — mobile](https://raw.githubusercontent.com/JorgeT10/kinkyvibe/pr46-assets/rt-material-mobile.png)
